### PR TITLE
 Add GRPO Trainer and Verifiers Environment for SQL Training

### DIFF
--- a/src/training/environment.py
+++ b/src/training/environment.py
@@ -1,0 +1,234 @@
+"""
+Verifiers environment setup for SQL GRPO training.
+"""
+import logging
+from typing import Optional
+import verifiers as vf
+from datasets import Dataset
+
+from ..rewards.sql_reward import create_sql_reward
+
+
+logger = logging.getLogger(__name__)
+
+
+class SQLEnvironment:
+    """
+    Factory for creating SQL training environments.
+    """
+    
+    def __init__(
+        self,
+        env_config,
+        reward_config
+    ):
+        """
+        Initialize environment factory.
+        
+        Args:
+            env_config: EnvironmentConfig object
+            reward_config: RewardConfig object
+        """
+        self.env_config = env_config
+        self.reward_config = reward_config
+        self.environment: Optional[vf.Environment] = None
+    
+    def create_single_turn_env(
+        self,
+        dataset: Dataset,
+        reward_type: str = "combined"
+    ) -> vf.SingleTurnEnv:
+        """
+        Create SingleTurnEnv for SQL generation.
+        
+        Args:
+            dataset: Training dataset with 'prompt' and 'answer' columns
+            reward_type: Type of reward function to use
+        
+        Returns:
+            Configured SingleTurnEnv
+        """
+        logger.info(f"Creating SingleTurnEnv with {reward_type} reward")
+        
+        # Create reward function
+        reward_fn = create_sql_reward(self.reward_config, reward_type)
+        
+        # Create rubric
+        if self.env_config.use_xml_format:
+            # Use XML parser for structured output
+            parser = vf.XMLParser(self.env_config.xml_tags)
+            rubric = vf.Rubric(
+                reward_fn,
+                parser.get_format_reward_func(),
+                weights=[0.9, 0.1]  # 90% correctness, 10% format
+            )
+            system_prompt = f"""{self.env_config.system_prompt}
+
+Output your response in the following format:
+<think>Your reasoning process here</think>
+<answer>Your SQL query here</answer>"""
+        else:
+            # Simple reward without format requirements
+            rubric = vf.Rubric(reward_fn)
+            system_prompt = self.env_config.system_prompt
+        
+        # Create environment
+        env = vf.SingleTurnEnv(
+            dataset=dataset,
+            rubric=rubric,
+            system_prompt=system_prompt,
+        )
+        
+        self.environment = env
+        logger.info("✓ Environment created")
+        
+        return env
+    
+    def create_multi_turn_env(
+        self,
+        dataset: Dataset,
+        reward_type: str = "combined",
+        max_turns: int = 3
+    ) -> vf.MultiTurnEnv:
+        """
+        Create MultiTurnEnv for iterative SQL refinement.
+        
+        This allows the model to receive feedback and refine queries.
+        
+        Args:
+            dataset: Training dataset
+            reward_type: Type of reward function
+            max_turns: Maximum conversation turns
+        
+        Returns:
+            Configured MultiTurnEnv
+        """
+        logger.info(f"Creating MultiTurnEnv with {reward_type} reward")
+        
+        # Create reward function
+        reward_fn = create_sql_reward(self.reward_config, reward_type)
+        rubric = vf.Rubric(reward_fn)
+        
+        # For multi-turn, we could implement a custom environment
+        # that provides feedback after each SQL attempt
+        # This is more advanced and requires custom implementation
+        
+        raise NotImplementedError(
+            "MultiTurnEnv for SQL refinement not yet implemented. "
+            "Use SingleTurnEnv for now."
+        )
+    
+    def validate_environment(self) -> bool:
+        """
+        Validate environment is properly configured.
+        
+        Returns:
+            True if valid
+        """
+        if self.environment is None:
+            logger.error("Environment not created")
+            return False
+        
+        # Check dataset
+        dataset = self.environment.get_dataset()
+        if dataset is None or len(dataset) == 0:
+            logger.error("Environment has no dataset")
+            return False
+        
+        # Check required columns
+        required_cols = {'prompt', 'answer'}
+        if not required_cols.issubset(dataset.column_names):
+            logger.error(f"Dataset missing columns: {required_cols - set(dataset.column_names)}")
+            return False
+        
+        logger.info("✓ Environment validation passed")
+        return True
+    
+    def test_environment(
+        self,
+        num_samples: int = 1,
+        client = None
+    ):
+        """
+        Test environment with sample rollouts.
+        
+        Args:
+            num_samples: Number of samples to test
+            client: OpenAI client for generation (optional)
+        """
+        if self.environment is None:
+            logger.error("Environment not created")
+            return
+        
+        logger.info(f"Testing environment with {num_samples} samples...")
+        
+        dataset = self.environment.get_dataset()
+        
+        for i in range(min(num_samples, len(dataset))):
+            sample = dataset[i]
+            print(f"\n{'='*60}")
+            print(f"TEST SAMPLE {i+1}")
+            print(f"{'='*60}")
+            print(f"\nPrompt:\n{sample['prompt'][:300]}...")
+            print(f"\nGround Truth:\n{sample['answer']}")
+            
+            if client:
+                # Test with actual generation
+                try:
+                    # This would require vLLM or OpenAI client setup
+                    # For now, just test reward function
+                    pass
+                except Exception as e:
+                    logger.error(f"Generation test failed: {e}")
+            
+            # Test reward function with ground truth
+            reward = self.environment.rubric.reward_functions[0](
+                prompt=sample['prompt'],
+                completion=sample['answer'],
+                answer=sample['answer'],
+                context=sample.get('context', '')
+            )
+            
+            print(f"\nReward for ground truth: {reward:.3f}")
+            print(f"{'='*60}\n")
+
+
+def create_environment(
+    dataset: Dataset,
+    env_config,
+    reward_config,
+    reward_type: str = "combined",
+    use_multi_turn: bool = False
+) -> vf.Environment:
+    """
+    Convenience function to create environment.
+    
+    Args:
+        dataset: Training dataset
+        env_config: EnvironmentConfig
+        reward_config: RewardConfig
+        reward_type: Type of reward ("syntax", "execution", "semantic", "combined")
+        use_multi_turn: Whether to use multi-turn environment
+    
+    Returns:
+        Configured environment
+    """
+    factory = SQLEnvironment(env_config, reward_config)
+    
+    if use_multi_turn:
+        env = factory.create_multi_turn_env(
+            dataset,
+            reward_type=reward_type,
+            max_turns=env_config.max_turns
+        )
+    else:
+        env = factory.create_single_turn_env(
+            dataset,
+            reward_type=reward_type
+        )
+    
+    # Validate
+    if not factory.validate_environment():
+        raise ValueError("Environment validation failed")
+    
+    return env

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -1,0 +1,223 @@
+"""
+GRPO trainer setup and execution.
+"""
+import logging
+import os
+from typing import Optional
+import verifiers as vf
+from transformers import AutoTokenizer
+from peft import PeftModel
+
+from ..models.model_loader import load_base_model_for_merge
+from .environment import SQLEnvironment
+
+
+logger = logging.getLogger(__name__)
+
+
+class GRPOTrainerWrapper:
+    """
+    Wrapper for verifiers GRPOTrainer with lifecycle management.
+    """
+    
+    def __init__(
+        self,
+        model,
+        tokenizer: AutoTokenizer,
+        environment: vf.Environment,
+        grpo_config,
+        peft_config=None
+    ):
+        """
+        Initialize GRPO trainer wrapper.
+        
+        Args:
+            model: Model to train
+            tokenizer: Tokenizer
+            environment: Verifiers environment
+            grpo_config: GRPOConfig object
+            peft_config: Optional PEFT config
+        """
+        self.model = model
+        self.tokenizer = tokenizer
+        self.environment = environment
+        self.grpo_config = grpo_config
+        self.peft_config = peft_config
+        self.trainer: Optional[vf.GRPOTrainer] = None
+    
+    def create_trainer(self) -> vf.GRPOTrainer:
+        """
+        Create GRPOTrainer instance.
+        
+        Returns:
+            Configured GRPOTrainer
+        """
+        logger.info("Creating GRPOTrainer...")
+        
+        # Create training arguments using grpo_defaults
+        args = vf.grpo_defaults(
+            run_name=self.grpo_config.run_name,
+            output_dir=self.grpo_config.output_dir,
+            num_train_epochs=self.grpo_config.num_train_epochs,
+            per_device_train_batch_size=self.grpo_config.per_device_train_batch_size,
+            gradient_accumulation_steps=self.grpo_config.gradient_accumulation_steps,
+            learning_rate=self.grpo_config.learning_rate,
+            max_seq_len=self.grpo_config.max_seq_len,
+            max_prompt_length=self.grpo_config.max_prompt_length,
+            max_tokens=self.grpo_config.max_tokens,
+            num_generations=self.grpo_config.num_generations,
+            beta=self.grpo_config.beta,
+            optim=self.grpo_config.optim,
+            max_grad_norm=self.grpo_config.max_grad_norm,
+            warmup_ratio=self.grpo_config.warmup_ratio,
+            lr_scheduler_type=self.grpo_config.lr_scheduler_type,
+            bf16=self.grpo_config.bf16,
+            tf32=self.grpo_config.tf32,
+            gradient_checkpointing=self.grpo_config.gradient_checkpointing,
+            save_strategy=self.grpo_config.save_strategy,
+            logging_steps=self.grpo_config.logging_steps,
+            push_to_hub=self.grpo_config.push_to_hub,
+            report_to=self.grpo_config.report_to,
+            sync_ref_model=self.grpo_config.sync_ref_model,
+        )
+        
+        # Add ref_model_sync_steps if specified
+        if self.grpo_config.ref_model_sync_steps:
+            args.ref_model_sync_steps = self.grpo_config.ref_model_sync_steps
+        
+        # Create trainer
+        self.trainer = vf.GRPOTrainer(
+            model=self.model,
+            processing_class=self.tokenizer,  # Note: processing_class, not tokenizer
+            env=self.environment,
+            args=args,
+            peft_config=self.peft_config,
+        )
+        
+        logger.info("✓ GRPOTrainer created")
+        return self.trainer
+    
+    def train(self, resume_from_checkpoint: bool = True):
+        """
+        Execute training.
+        
+        Args:
+            resume_from_checkpoint: Whether to resume from checkpoint
+        """
+        if self.trainer is None:
+            self.create_trainer()
+        
+        logger.info("Starting GRPO training...")
+        logger.info(f"Output directory: {self.grpo_config.output_dir}")
+        logger.info(f"Training epochs: {self.grpo_config.num_train_epochs}")
+        logger.info(f"Batch size: {self.grpo_config.per_device_train_batch_size}")
+        logger.info(f"Gradient accumulation: {self.grpo_config.gradient_accumulation_steps}")
+        logger.info(f"Num generations: {self.grpo_config.num_generations}")
+        
+        # Train
+        self.trainer.train(resume_from_checkpoint=resume_from_checkpoint)
+        
+        logger.info("✓ Training completed")
+    
+    def save_model(self):
+        """Save trained model adapters."""
+        if self.trainer is None:
+            logger.error("Trainer not created")
+            return
+        
+        logger.info(f"Saving model to {self.grpo_config.output_dir}...")
+        self.trainer.save_model()
+        logger.info("✓ Model saved")
+    
+    def merge_and_save(self, model_config):
+        """
+        Merge LoRA adapters with base model and save.
+        
+        Args:
+            model_config: ModelConfig object
+        """
+        import torch
+        import gc
+        
+        logger.info("Merging LoRA adapters with base model...")
+        
+        output_dir = self.grpo_config.output_dir
+        merged_dir = os.path.join(output_dir, "merged")
+        
+        # Free memory
+        logger.info("Freeing GPU memory...")
+        del self.model
+        del self.trainer
+        torch.cuda.empty_cache()
+        gc.collect()
+        
+        # Load base model
+        logger.info("Loading base model...")
+        base_model = load_base_model_for_merge(
+            model_config.model_id,
+            model_config
+        )
+        
+        # Load tokenizer from trained model
+        tokenizer = AutoTokenizer.from_pretrained(output_dir)
+        
+        # Apply chat format
+        from trl import setup_chat_format
+        base_model, tokenizer = setup_chat_format(base_model, tokenizer)
+        
+        # Load PEFT adapter
+        logger.info("Loading PEFT adapter...")
+        peft_model = PeftModel.from_pretrained(
+            base_model,
+            output_dir,
+            torch_dtype=torch.bfloat16,
+        )
+        
+        # Merge
+        logger.info("Merging adapters...")
+        merged_model = peft_model.merge_and_unload()
+        
+        # Save
+        logger.info(f"Saving merged model to {merged_dir}...")
+        os.makedirs(merged_dir, exist_ok=True)
+        merged_model.save_pretrained(merged_dir, safe_serialization=True)
+        tokenizer.save_pretrained(merged_dir)
+        
+        logger.info("✓ Merged model saved")
+        
+        # Cleanup
+        del base_model, peft_model, merged_model
+        torch.cuda.empty_cache()
+        gc.collect()
+
+
+def create_trainer(
+    model,
+    tokenizer: AutoTokenizer,
+    environment: vf.Environment,
+    grpo_config,
+    peft_config=None
+) -> GRPOTrainerWrapper:
+    """
+    Convenience function to create trainer.
+    
+    Args:
+        model: Model to train
+        tokenizer: Tokenizer
+        environment: Training environment
+        grpo_config: GRPOConfig
+        peft_config: Optional PEFT config
+    
+    Returns:
+        Configured trainer wrapper
+    """
+    wrapper = GRPOTrainerWrapper(
+        model=model,
+        tokenizer=tokenizer,
+        environment=environment,
+        grpo_config=grpo_config,
+        peft_config=peft_config
+    )
+    
+    wrapper.create_trainer()
+    return wrapper


### PR DESCRIPTION
## Summary
This PR introduces two core components for text-to-SQL reinforcement learning using the **Verifiers GRPO framework**:
- A `GRPOTrainerWrapper` class that orchestrates GRPO training and lifecycle management, including LoRA adapter merging.
- An `SQLEnvironment` factory for building, validating, and testing single-turn environments for SQL generation tasks using reward functions from `sql_reward.py`.

Together, these modules complete the foundation for end-to-end GRPO-based fine-tuning of SQL generation models.

---

## Modules Added

### 1. `environment.py`
Factory and utilities for creating Verifiers-compatible training environments for SQL tasks.

**Key Features**
- **`SQLEnvironment`**
  - Encapsulates creation of **single-turn** and **multi-turn** SQL environments.  
  - Integrates `sql_reward.create_sql_reward()` for configurable reward types (`syntax`, `execution`, `semantic`, `combined`).  
  - Supports **XML-structured output formats**, using Verifiers’ `XMLParser` and `Rubric` for multi-component reward computation.  
  - Provides dataset validation and quick environment sanity checks via `test_environment()`.  
- **Convenience function** `create_environment()`:
  - Simplifies environment instantiation and validation.
  - Handles automatic selection between single- and multi-turn modes.
- **Multi-turn support placeholder**:  
  A stub for iterative SQL refinement environments, with the interface scaffolded for future implementation.

**Rationale**  
Provides a clean, reusable interface to initialize SQL environments with minimal boilerplate. This enables direct integration with `verifiers.GRPOTrainer`, keeping the training setup modular and decoupled from model logic.

---

### 2. `trainer.py`
Implements the training logic and model lifecycle management for GRPO-based fine-tuning.

**Key Features**
- **`GRPOTrainerWrapper`**
  - Wraps Verifiers’ `GRPOTrainer` and centralizes configuration, training, and checkpoint management.
  - Automatically generates GRPO training arguments using `vf.grpo_defaults`.
  - Tracks lifecycle stages: initialization, training, saving, and adapter merging.
- **`train()`**
  - Runs the full GRPO training loop with checkpoint resumption and structured logging of hyperparameters.
- **`save_model()`**
  - Persists model adapters to the output directory after training.
- **`merge_and_save()`**
  - Reloads the base model and merges LoRA adapters into a fully consolidated model.
  - Handles GPU memory cleanup and serialization using `PeftModel.merge_and_unload()`.
- **Convenience function** `create_trainer()`:
  - Simplifies construction of the trainer wrapper for quick setup in scripts or notebooks.

**Rationale**  
Provides a unified abstraction over the GRPO training pipeline, making it easier to integrate PEFT fine-tuning, reward environments, and model checkpointing under a single lifecycle-managed interface.

---

## Interaction Between Modules
- The `GRPOTrainerWrapper` depends on an environment created by `SQLEnvironment` or `create_environment()`.
- The environment internally composes SQL rewards (syntax, execution, semantic) defined in `sql_reward.py`.
- This modular separation ensures:
  - Trainer logic remains agnostic to domain details (e.g., SQL-specific rewards).
  - Reward composition and schema handling remain testable in isolation.
  - GRPO training workflows can be reused for other structured tasks with minimal modification.

---

## Example Usage

```python
from text_to_sql_coder.training.trainer import create_trainer
from text_to_sql_coder.training.environment import create_environment
from text_to_sql_coder.config import GRPOConfig, EnvironmentConfig, RewardConfig
from datasets import load_dataset

# Load dataset
dataset = load_dataset("chrisjcc/sql-text-to-sql", split="train")

# Create environment
env = create_environment(dataset, EnvironmentConfig(), RewardConfig(), reward_type="combined")

# Initialize model and tokenizer (example)
model, tokenizer = load_base_model_for_merge("mistralai/Mistral-7B-v0.3")

# Create trainer
trainer = create_trainer(model, tokenizer, env, GRPOConfig())

# Train and save
trainer.train()
trainer.save_model()
trainer.merge_and_save(model_config)

### Impact

- Adds a full GRPO training and evaluation loop for SQL-based tasks.
- Enables integration of structured reward functions into Verifiers environments.
- Facilitates future extensions (multi-turn SQL refinement, cross-database reward evaluation).

### Next Steps

- Implement `MultiTurnEnv` for iterative query correction and refinement.
- Add integration tests for trainer-environment lifecycle.
- Benchmark reward sensitivity across syntax/execution/semantic weight configurations.
- Extend `merge_and_save()` to support distributed merging for large-scale adapters.